### PR TITLE
Update 类型判断.md

### DIFF
--- a/src/Part-进阶技巧/类型判断.md
+++ b/src/Part-进阶技巧/类型判断.md
@@ -13,3 +13,18 @@ func _on_body_entered(body):
 ```
 
 其中，`body is 敌人` 会在 body 为敌人类或敌人子类的实例时得到 true，否则为 false。
+
+另一种判断方法是使用 `is_instance_of` 用于覆盖动态类型检查，更多信息见引擎内置文档。
+
+```gdscript
+func _is_resource(resource: Resource, type) -> bool:
+	if resource == null:
+		return false
+		
+	return is_instance_of(resource, type)
+
+var 非全局类资源 = preload("资源.gd")
+
+if _is_resource(资源实例，非全局内资源):
+    pass
+```


### PR DESCRIPTION
增加is_instance_of的介绍。因为rc3时修改了is的用法，去掉了自 godot3 以来的检测动态类型的能力，为了兼容，引入了这个方法。当时也一堆人反馈怎么 is 不行了😅。